### PR TITLE
Fix path in rm command for qbit-matui.zip

### DIFF
--- a/root/etc/cont-init.d/98-install-qbit-matui
+++ b/root/etc/cont-init.d/98-install-qbit-matui
@@ -20,7 +20,7 @@ if [ ! -d /qbit-matui ]; then
     unzip qbit-matui.zip -d /
 
   # Remove zip after unpacking
-  rm /qbit-matui.zip
+  rm qbit-matui.zip
 
   mv /qbit-mat* /qbit-matui
 


### PR DESCRIPTION
This pull request fixes the path in the rm command for qbit-matui.zip by removing the leading slash. The zip is previously correctly referenced without the leading slash, but since it is later referenced with a slash, it has an error if the script is run from a different directory (such as suggested by issue [#1](https://github.com/marzzzello/linuxserver-io-mod-qbit-matui/issues/1)).